### PR TITLE
Add backend models and support classes

### DIFF
--- a/server/app/Models/AdminAction.php
+++ b/server/app/Models/AdminAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class AdminAction extends Model
+{
+    public const TARGET_USER = 'user';
+    public const TARGET_FORUM_POST = 'forum_post';
+    public const TARGET_FORUM_REPLY = 'forum_reply';
+    public const TARGET_JOB = 'job';
+
+    protected $fillable = ['admin_id','action_type','target_type','target_id','reason'];
+
+    public function admin() { return $this->belongsTo(User::class, 'admin_id'); }
+}

--- a/server/app/Models/EmployerProfile.php
+++ b/server/app/Models/EmployerProfile.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EmployerProfile extends Model
+{
+    protected $fillable = ['user_id','company_name','company_website','company_description','company_location'];
+
+    public function user() { return $this->belongsTo(User::class); }
+}

--- a/server/app/Models/ForumPost.php
+++ b/server/app/Models/ForumPost.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ForumPost extends Model
+{
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_HIDDEN = 'hidden';
+    public const STATUS_DELETED = 'deleted';
+
+    protected $fillable = ['user_id','title','content','status'];
+
+    public function user() { return $this->belongsTo(User::class); }
+
+    public function replies() { return $this->hasMany(ForumReply::class, 'post_id'); }
+
+    public function skills() { return $this->belongsToMany(Skill::class, 'forum_post_skill')->withTimestamps(); }
+}

--- a/server/app/Models/ForumReply.php
+++ b/server/app/Models/ForumReply.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ForumReply extends Model
+{
+    protected $fillable = ['post_id','user_id','content'];
+
+    public function post() { return $this->belongsTo(ForumPost::class, 'post_id'); }
+
+    public function user() { return $this->belongsTo(User::class); }
+}

--- a/server/app/Models/Job.php
+++ b/server/app/Models/Job.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Job extends Model
+{
+    public const STATUS_OPEN   = 'open';
+    public const STATUS_CLOSED = 'closed';
+
+    public const TYPE_FULL_TIME = 'full_time';
+    public const TYPE_PART_TIME = 'part_time';
+    public const TYPE_INTERN    = 'intern';
+    public const TYPE_REMOTE    = 'remote';
+
+    protected $fillable = [
+        'employer_id','title','description','location','job_type','salary_range','deadline','status'
+    ];
+
+    public function employer() { return $this->belongsTo(User::class, 'employer_id'); }
+
+    public function skills() { return $this->belongsToMany(Skill::class, 'job_skill')->withPivot('importance')->withTimestamps(); }
+
+    public function applications() { return $this->hasMany(JobApplication::class); }
+}

--- a/server/app/Models/JobApplication.php
+++ b/server/app/Models/JobApplication.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class JobApplication extends Model
+{
+    public const STATUS_APPLIED     = 'applied';
+    public const STATUS_REVIEWED    = 'reviewed';
+    public const STATUS_SHORTLISTED = 'shortlisted';
+    public const STATUS_REJECTED    = 'rejected';
+
+    protected $fillable = ['job_id','job_seeker_id','cover_letter','cv_url','status','applied_at'];
+
+    protected $casts = ['applied_at' => 'datetime'];
+
+    public function job() { return $this->belongsTo(Job::class); }
+
+    public function jobSeeker() { return $this->belongsTo(User::class, 'job_seeker_id'); }
+}

--- a/server/app/Models/JobSeekerProfile.php
+++ b/server/app/Models/JobSeekerProfile.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class JobSeekerProfile extends Model
+{
+    protected $fillable = ['user_id','bio','education','experience','portfolio_url','linkedin_url'];
+
+    public function user() { return $this->belongsTo(User::class); }
+}

--- a/server/app/Models/MentorProfile.php
+++ b/server/app/Models/MentorProfile.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MentorProfile extends Model
+{
+    protected $fillable = ['user_id','headline','bio','expertise'];
+
+    public function user() { return $this->belongsTo(User::class); }
+}

--- a/server/app/Models/Skill.php
+++ b/server/app/Models/Skill.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Skill extends Model
+{
+    protected $fillable = ['name'];
+
+    public function users() { return $this->belongsToMany(User::class)->withPivot('level')->withTimestamps(); }
+
+    public function jobs() { return $this->belongsToMany(Job::class, 'job_skill')->withPivot('importance')->withTimestamps(); }
+
+    public function forumPosts() { return $this->belongsToMany(ForumPost::class, 'forum_post_skill')->withTimestamps(); }
+}

--- a/server/app/Models/User.php
+++ b/server/app/Models/User.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models;
+use Tymon\JWTAuth\Contracts\JWTSubject;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class User extends Authenticatable implements JWTSubject
+{
+    use HasFactory, Notifiable;
+   
+    public const ROLE_JOB_SEEKER = 'job_seeker';
+    public const ROLE_EMPLOYER   = 'employer';
+    public const ROLE_MENTOR     = 'mentor';
+    public const ROLE_ADMIN      = 'admin';
+
+    public const STATUS_ACTIVE = 'active';
+    public const STATUS_BANNED = 'banned';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'role',
+        'status',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    public function jobSeekerProfile()
+    {
+        return $this->hasOne(JobSeekerProfile::class);
+    }
+
+    public function employerProfile()
+    {
+        return $this->hasOne(EmployerProfile::class);
+    }
+
+    public function mentorProfile()
+    {
+        return $this->hasOne(MentorProfile::class);
+    }
+
+    public function skills()
+    {
+        return $this->belongsToMany(Skill::class)
+            ->withPivot('level')
+            ->withTimestamps();
+    }
+
+    public function jobsPosted()
+    {
+        return $this->hasMany(Job::class, 'employer_id');
+    }
+
+    public function applications()
+    {
+        return $this->hasMany(JobApplication::class, 'job_seeker_id');
+    }
+
+    public function forumPosts()
+    {
+        return $this->hasMany(ForumPost::class);
+    }
+
+    public function forumReplies()
+    {
+        return $this->hasMany(ForumReply::class);
+    }
+
+    public function adminActions()
+    {
+        return $this->hasMany(AdminAction::class, 'admin_id');
+    }
+
+    public function getJWTIdentifier()
+{
+    return $this->getKey();
+}
+
+public function getJWTCustomClaims()
+{
+    return [];
+}
+
+}

--- a/server/app/Support/Constants.php
+++ b/server/app/Support/Constants.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Support;
+
+class Constants
+{
+    public const USER_ROLES = ['job_seeker','employer','mentor','admin'];
+
+    public const USER_STATUS = ['active','banned'];
+
+    public const JOB_STATUS = ['open','closed'];
+    public const JOB_TYPES  = ['full_time','part_time','intern','remote'];
+
+    public const APPLICATION_STATUS = ['applied','reviewed','shortlisted','rejected'];
+
+    public const FORUM_POST_STATUS = ['active','hidden','deleted'];
+}


### PR DESCRIPTION
## Summary
Adds initial backend Eloquent models and a central Constants class for roles/status.

## Changes
- Added models:
  - AdminAction, EmployerProfile, JobSeekerProfile, MentorProfile
  - Job, JobApplication
  - ForumPost, ForumReply
  - Skill, User
- Added `server/app/Support/Constants.php` for shared roles/status constants.

## Notes
- No migrations/routes/controllers included in this PR — only model + constants scaffolding.

## Related
Closes #3